### PR TITLE
Complie error in schema file

### DIFF
--- a/WindowListGroup@jake.phy@gmail.com/org.cinnamon.applets.windowListGroup.gschema.xml
+++ b/WindowListGroup@jake.phy@gmail.com/org.cinnamon.applets.windowListGroup.gschema.xml
@@ -68,42 +68,4 @@
       <description>The applications corresponding to these identifiers will be displayed in the favorites area.</description>
     </key>
   </schema>
-  <schema path="/org/cinnamon/applets/windowListGroup/keybindings/" id="org.cinnamon.applets.windowListGroup.keybindings">
-    <key type="as" name="launch-app-key-1">
-      <default><![CDATA[['<Super>1']]]></default>
-      <summary>open new window using keyboard</summary>
-    </key>
-    <key type="as" name="launch-app-key-2">
-      <default><![CDATA[['<Super>2']]]></default>
-      <summary>open new window using keyboard</summary>
-    </key>
-    <key type="as" name="launch-app-key-3">
-      <default><![CDATA[['<Super>3']]]></default>
-      <summary>open new window using keyboard</summary>
-    </key>
-    <key type="as" name="launch-app-key-4">
-      <default><![CDATA[['<Super>4']]]></default>
-      <summary>open new window using keyboard</summary>
-    </key>
-    <key type="as" name="launch-app-key-5">
-      <default><![CDATA[['<Super>5']]]></default>
-      <summary>open new window using keyboard</summary>
-    </key>
-    <key type="as" name="launch-app-key-6">
-      <default><![CDATA[['<Super>6']]]></default>
-      <summary>open new window using keyboard</summary>
-    </key>
-    <key type="as" name="launch-app-key-7">
-      <default><![CDATA[['<Super>7']]]></default>
-      <summary>open new window using keyboard</summary>
-    </key>
-    <key type="as" name="launch-app-key-8">
-      <default><![CDATA[['<Super>8']]]></default>
-      <summary>open new window using keyboard</summary>
-    </key>
-    <key type="as" name="launch-app-key-9">
-      <default><![CDATA[['<Super>9']]]></default>
-      <summary>open new window using keyboard</summary>
-    </key>
-  </schema>
 </schemalist>


### PR DESCRIPTION
Key bindings schema section is causing errors during schema compile, which causes the compiler to ignore the whole file. Removed the bindings until a better solution can be found. With the section removed, the applet doesn't work in the current state.

Code change : 
Removed the schema corresponding to key bindings.
