### PR TITLE
Make super+number keyboard shortcut behave the same as clicking on icon

### DIFF
--- a/WindowListGroup@jake.phy@gmail.com/applet.js
+++ b/WindowListGroup@jake.phy@gmail.com/applet.js
@@ -589,8 +589,12 @@ AppGroup.prototype = {
     },
 
     _onAppKeyPress: function (number) {
-        this.app.open_new_window(-1);
-        this._animate();
+        if (this.isFavapp) {
+            this.app.open_new_window(-1);
+            this._animate();
+        } else {
+            this._windowHandle(false);
+        }
     },
 
     _windowHandle: function (fromDrag) {


### PR DESCRIPTION
If I understand correctly, your goal is to make this applet work like the app group switcher in Win7. I believe this change will make it behave more like Win7. This change will make the super+number keyboard shortcut behave the same as clicking an app group icon rather than opening a new window instance.
