### PR TITLE
Added two features: move to monitor and open new app keybinding

### DIFF
--- a/WindowListGroup@jake.phy@gmail.com/applet.js
+++ b/WindowListGroup@jake.phy@gmail.com/applet.js
@@ -624,8 +624,10 @@ AppGroup.prototype = {
     },
 
     _newAppKeyNumber: function (number) {
-        if (number < 10)
+        if (number < 10){
             Main.keybindingManager.addHotKey('launch-app-key-' + number.toString(), "<Super>" + number.toString(), Lang.bind(this, this._onAppKeyPress));
+            Main.keybindingManager.addHotKey('launch-new-app-key-' + number.toString(), "<Super><Shift>" + number.toString(), Lang.bind(this, this._onNewAppKeyPress));
+        }
     },
 
     _onAppKeyPress: function (number) {
@@ -635,6 +637,11 @@ AppGroup.prototype = {
         } else {
             this._windowHandle(false);
         }
+    },
+    
+    _onNewAppKeyPress: function (number) {
+        this.app.open_new_window(-1);
+        this._animate();
     },
 
     _windowHandle: function (fromDrag) {

--- a/WindowListGroup@jake.phy@gmail.com/applet.js
+++ b/WindowListGroup@jake.phy@gmail.com/applet.js
@@ -914,7 +914,7 @@ AppList.prototype = {
         this.orientation = orientation;
         this._applet = applet;
 
-        this.myactorbox = new SpecialButtons.MyAppletBox(this);
+        this.myactorbox = new SpecialButtons.MyAppletBox(this._applet);
         this.actor = this.myactorbox.actor;
 
         if (orientation == St.Side.TOP) {

--- a/WindowListGroup@jake.phy@gmail.com/specialMenus.js
+++ b/WindowListGroup@jake.phy@gmail.com/specialMenus.js
@@ -97,10 +97,10 @@ AppMenuButtonRightClickMenu.prototype = {
         this.favs = PinnedFavorites, this.favId = this.app.get_id(), this.isFav = this.favs.isFavorite(this.favId);
         if (this._applet.showPinned != FavType.none) {
             if (this.isFav) {
-                this.itemtoggleFav = new PopupMenu.PopupMenuItem(_('Unpin Favorite'));
+                this.itemtoggleFav = new PopupMenu.PopupMenuItem(_('Unpin App'));
                 this.itemtoggleFav.connect('activate', Lang.bind(this, this._toggleFav));
             } else {
-                this.itemtoggleFav = new PopupMenu.PopupMenuItem(_('Pin To Favorites'));
+                this.itemtoggleFav = new PopupMenu.PopupMenuItem(_('Pin App'));
                 this.itemtoggleFav.connect('activate', Lang.bind(this, this._toggleFav));
             }
         }
@@ -238,11 +238,11 @@ AppMenuButtonRightClickMenu.prototype = {
         if (this.isFav) {
             this.close(false);
             this.favs.removeFavorite(this.favId)
-            this.itemtoggleFav.label.text = _('Pin To Favorites');
+            this.itemtoggleFav.label.text = _('Pin App');
         } else {
             this.close(false);
             this.favs.addFavorite(this.favId);
-            this.itemtoggleFav.label.text = _('Unpin Favorite');
+            this.itemtoggleFav.label.text = _('Unpin App');
         }
     },
 


### PR DESCRIPTION
## Move to monitor.
* `<Super><Shift>Left` and `<Super><Shift>Right` move the currently active window left or right from your current monitor.
* In the right click menu "Move to monitor X" is available for each monitor you have.

## Open new app window keybinding.
Using `<Super><Shift>Number` will open a new app instead of focus it.

These features are based off of the 2.7.5 release, rather than the current development version.