### PR TITLE
Fixed bug: App icon not removed from a panel

### DIFF
--- a/WindowListGroup@jake.phy@gmail.com/applet.js
+++ b/WindowListGroup@jake.phy@gmail.com/applet.js
@@ -918,14 +918,7 @@ AppList.prototype = {
             }
             this.actor.add_actor(appGroup.actor);
 
-            // We also need to monitor the state 'cause some pesky apps (namely: plugin_container left over after fullscreening a flash video)
-            // don't report having zero windows after they close
-            app.connect('notify::state', Lang.bind(this, function (app) {
-                if (app.state == Cinnamon.AppState.STOPPED && this._appList[app]) {
-                    this._removeApp(app);
-                    appGroup._calcWindowNumber(metaWorkspace);
-                }
-            }));
+            app.connect('windows-changed', Lang.bind(this, this._onAppWindowsChanged, app));
 
             this._appList[app] = {
                 appGroup: appGroup,
@@ -936,6 +929,26 @@ AppList.prototype = {
             if (this._applet.settings.getValue("title-display") == TitleDisplay.focused)
                 appGroup.hideAppButtonLabel(false);
         }
+    },
+
+    _onAppWindowsChanged: function (app) {
+        let numberOfwindows = this._getNumberOfAppWindowsInWorkspace(app, this.metaWorkspace);
+        if (numberOfwindows == 0) {
+            this._removeApp(app);
+        }
+    },
+
+    _getNumberOfAppWindowsInWorkspace: function (app, workspace) {
+        var windows = app.get_windows();
+        let result = 0;
+
+        for(var i = 0; i < windows.length; i++) {
+            let windowWorkspace = windows[i].get_workspace();
+            if(windowWorkspace.index() == workspace.index()) {
+                ++result;
+            }
+        }
+        return result;
     },
 
     _removeApp: function (app) {


### PR DESCRIPTION
**:beetle: Description:** 
App icon is not removed from a panel when using more than one workspace.

**Details:**
"notify::state" signal is not being sent because there are opened app windows in other workspaces.

**Steps to reproduce:**
1. Open an unpinned app window in the first workspace. For example open a terminal window in the first worskpace.
2. Switch to the second workspace: <kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>&rarr;</kbd> 
3. Open a terminal window in the second workspace.
4. Close the terminal window in the second workspace.

**Actual result:**
Terminal icon remains on a panel in the second workspace.

**Expected result:**
Terminal icon is removed from a panel in the second workspace.

**Solution:**
Connect "windows-changed" signal.
A signal handler is called when app window is opened or closed.
Remove app icon from a panel if there is no app window in the workspace.