### PR TITLE
Title Display: pinned; non-pinned

### DIFF
--- a/WindowListGroup@jake.phy@gmail.com/applet.js
+++ b/WindowListGroup@jake.phy@gmail.com/applet.js
@@ -370,6 +370,17 @@ AppGroup.prototype = {
     getId: function() {
         return this.app.get_id();
     },
+    
+    /**
+     * Checks whether the id of this app is listed among pinned-apps.
+     * @return True if the id is listed.
+     */
+    isPinned: function() {
+        let name = this.getId();
+        let pinnedApps = this._applet.settings.getValue("pinned-apps");
+        let pinned = pinnedApps.indexOf(name)>=0;
+        return pinned;
+    },
 
     on_arrange_pinned: function () {
         this._draggable.inhibit = !this._applet.settings.getValue("arrange-pinnedApps");
@@ -387,7 +398,11 @@ AppGroup.prototype = {
             this.showAppButtonLabel(true);
         } else if (titleType == TitleDisplay.app) {
             this.showAppButtonLabel(true);
-        } else if (titleType == TitleDisplay.none) {
+        } else if (titleType == TitleDisplay.nonpinned && !this.isPinned()) {
+            this.showAppButtonLabel(true);
+        } else if (titleType == TitleDisplay.pinned && this.isPinned) {
+            this.showAppButtonLabel(true);
+        } else {
             this.hideAppButtonLabel(true);
         }
     },
@@ -709,7 +724,10 @@ AppGroup.prototype = {
 
         let titleType = this._applet.settings.getValue("title-display");
         let [title, appName] = [metaWindow.get_title(), this.app.get_name()];
-        if (titleType == TitleDisplay.title) {
+        
+        if (titleType == TitleDisplay.title
+                || (titleType == TitleDisplay.nonpinned && !this.isPinned())
+                || titleType == TitleDisplay.pinned && this.isPinned()) {
             if (title) {
                 this._appButton.setText(title);
                 this.showAppButtonLabel(true);
@@ -724,8 +742,9 @@ AppGroup.prototype = {
                 this._appButton.setText(appName);
                 this.showAppButtonLabel(true);
             }
-        } else if (titleType == TitleDisplay.none) {
+        } else {
             this._appButton.setText("");
+            this.hideAppButtonLabel(true);
         }
     },
 

--- a/WindowListGroup@jake.phy@gmail.com/applet.js
+++ b/WindowListGroup@jake.phy@gmail.com/applet.js
@@ -47,7 +47,9 @@ const TitleDisplay = {
     none: 1,
     app: 2,
     title: 3,
-    focused: 4
+    focused: 4,
+    nonpinned: 5,
+    pinned: 6
 };
 const NumberDisplay = {
     smart: 1,

--- a/WindowListGroup@jake.phy@gmail.com/settings-schema.json
+++ b/WindowListGroup@jake.phy@gmail.com/settings-schema.json
@@ -26,7 +26,9 @@
         "none" : 1,
         "app" : 2,
         "title" : 3,
-        "focused" : 4
+        "focused" : 4,
+        "nonpinned" : 5,
+        "pinned" : 6
     },
     "tooltip" : "focused: show focused window title, title: display the window title, app: diplay app name, none: don't display anything"
  },


### PR DESCRIPTION
This is a simple update, which adds two new options for Title Display option: Pinned and Non-pinned. These options display the title of the application group only if the app is pined, or not pinned, respectively.

I wrote this patch because I didn't want my pinned apps to display titles; feel free to add it to your project, should you find it useful.

Singon